### PR TITLE
Add Share section with QR code and Save Local tip

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,5 +235,23 @@
 
     setupGestureControl();
   </script>
+<section id="share" style="text-align: center; padding: 2em; background: #f9f9f9; color: #222;">
+  <h2 style="margin-bottom: 1em;">Share Hybrid Classical</h2>
+
+  <!-- Embedded QR Code -->
+
+
+  <img 
+  src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHQAAAB0AQAAAAB84SuKAAAA40lEQVR4nL2VsW1EMQxDnw7pqQ3+/mN5A2oCpvhX5HApzgYSVRLgB8kWQVf4GfPgNf6+rqqmizvZ55VQy7SS/f5fUAJR6dIRD1CkP5z3tzp64id8zKyxiff5SoEAGNDa75/EDNzJPt/QeLF6an9+YuPE2BDv8wJZsWLrgDe2IyxywmMQssgB/4BOJoCZ/fevp/AWKnxt75/IiaXE1sn9hYQBpJP9JYmcKMo+f/vP6ulbiGf+Q67BcKJ/qqGHKfrYT5dBXvvz3/4lGjzXkf+FHkyXfNJ/CnWayXxw/l2/L+W//1/frmOGzi/tt5UAAAAASUVORK5CYII=" 
+  alt="QR code linking to hybridclassical.ai" 
+  style="max-width: 200px; height: auto; border: 1px solid #ccc; padding: 0.5em; background: white;" 
+/>
+
+  <!-- Save Local Info -->
+  <p style="margin-top: 1.5em; font-size: 0.9em;">
+    <strong>Tip:</strong> On your phone, tap Share → <em>Add to Home Screen</em> to save this app locally.
+  </p>
+</section>
+
 </body>
 </html>


### PR DESCRIPTION
This adds a visually distinct Share section to the webapp, including:
- A scannable QR code linking to https://hybridclassical.ai
- A tip for saving the app locally on mobile devices

Useful in Open Studios and other public sharing settings.