### PR TITLE
Reorder load buttons (Internet first) and simplify label

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,14 +192,6 @@ iVBORw0KGgoAAAANSUhEUgAAAEsAAABuCAMAAABY8R5dAAAC91BMVEUAAAABCQv///9OUFDc3t5QU1NN
 
 Choose Music:
 
-<!-- Local file chooser -->
-<label for="audioInput"
-       style="display: inline-block; margin-top: 1em; padding: 0.5em 1em;
-              background-color: #444; color: #fff; border-radius: 5px; cursor: pointer;">
-📂 Local
-</label>
-<input type="file" id="audioInput" accept="audio/*, .mp3" style="display: none;">
-
 <!-- Online library button 
 <a href="https://www.hybridclassical.ai/library/"
    target="_blank" rel="noopener"
@@ -217,8 +209,20 @@ Choose Music:
    style="display:inline-block;margin-top:1em;margin-left:.5em;
           padding:.5em 1em;background:#444;color:#fff;border-radius:5px;
           text-decoration:none;cursor:pointer;">
-  🌐 Internet Library
+  🌐 Internet
 </a>
+
+<!-- Local file chooser -->
+<label for="audioInput"
+       style="display: inline-block; margin-top: 1em; padding: 0.5em 1em;
+              background-color: #444; color: #fff; border-radius: 5px; cursor: pointer;">
+📂 Local
+</label>
+
+<input type="file" id="audioInput" accept="audio/*, .mp3" style="display: none;">
+
+
+
 
 <!-- Allows direct URL input -->
 <button id="openUrl" 


### PR DESCRIPTION
Minor UX refinement.
• Moved “🌐 Internet” button before “📂 Local” for smoother mobile experience.
• Removed “Library” suffix for cleaner look and consistent spacing.