### PR TITLE
feat(picker): new-tab library picker with postMessage

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,14 +203,65 @@ Choose Music:
 -->
 
 <!-- Opens the curated library (existing behavior) -->
+
+
+
 <a id="openLibrary"
-   href="https://www.hybridclassical.ai/library/"
-   target="_blank" rel="noopener"
+   href="https://www.hybridclassical.ai/library/?mode=picker"
    style="display:inline-block;margin-top:1em;margin-left:.5em;
           padding:.5em 1em;background:#444;color:#fff;border-radius:5px;
           text-decoration:none;cursor:pointer;">
   🌐 Internet
 </a>
+
+<script>
+  // If your loader is named differently, change this to call yours.
+  async function loadFromUrl(src) {
+    // TODO: plug into your existing player logic.
+    // After successful load:
+    try { setShareUrl?.(src); } catch(_) {}
+  }
+
+  function openLibraryPicker(e) {
+    e.preventDefault(); // don't follow the link directly
+    const pickerUrl = document.getElementById('openLibrary').getAttribute('href');
+    // Open a real new tab/window and keep a reference so we can close it later.
+    const lib = window.open(pickerUrl, '_blank'); // no rel=noopener here
+
+    function onMsg(ev) {
+      // Only accept messages from your live domain:
+      const allowedOrigin = 'https://www.hybridclassical.ai';
+      if (ev.origin !== allowedOrigin) return;
+
+      const msg = ev.data || {};
+      if (msg.type === 'HC_SELECT_URL' && msg.url) {
+        loadFromUrl(msg.url);
+        try { lib && lib.close(); } catch(_) {}
+        window.removeEventListener('message', onMsg);
+      }
+    }
+    window.addEventListener('message', onMsg);
+  }
+
+  document.getElementById('openLibrary').addEventListener('click', openLibraryPicker);
+
+  // Optional deep-linking helper; harmless if you add later.
+  function setShareUrl(srcUrl) {
+    const u = new URL(window.location.href);
+    u.searchParams.set('u', srcUrl);
+    history.replaceState(null, '', u);
+  }
+
+  // Optional: auto-load if shared with ?u=...
+  (function bootFromParam() {
+    try {
+      const u = new URL(window.location.href).searchParams.get('u');
+      if (u) loadFromUrl(u);
+    } catch (_) {}
+  })();
+</script>
+
+
 
 <!-- Local file chooser -->
 <label for="audioInput"

--- a/library/index.html
+++ b/library/index.html
@@ -1,39 +1,69 @@
-<!doctype html>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Hybrid Classical – Library</title>
-<style>
-  body{font:16px/1.6 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:20px;max-width:800px}
-  h1{font-size:1.5em;margin-bottom:.75rem}
-  h2{margin-top:1.5rem}
-  ul{margin:.5rem 0 1.25rem 1rem}
-  a{color:#003366;text-decoration:none}
-  a:hover{text-decoration:underline}
-  .meta{font-size:.9em;color:#666}
-  .footer{margin-top:2rem;font-size:.9em}
-</style>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hybrid Classical | Library</title>
 
-<h1>Hybrid Classical – Library</h1>
-<p class="meta">Tap a piece to open it in the app. Links are privacy-safe and bookmarkable.</p>
+  <style>
+    body {
+      font: 16px/1.6 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      margin: 20px;
+      max-width: 800px;
+    }
+    h1 { font-size: 1.5em; margin-bottom: .75rem; }
+    h2 { margin-top: 1.5rem; }
+    ul { margin: .5rem 0 1.25rem 1rem; }
+    a { color: #003366; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .meta { font-size: .9em; color: #666; }
+    .footer { margin-top: 2rem; font-size: .9em; }
+  </style>
+</head>
 
-<h2>Rounds / Canons</h2>
-<ul>
-  <li><a href="/track/?id=frere_jacques.mp3">Frère Jacques</a></li>
-<!-- with category subfolder, if you want -->
-<!-- <li><a href="/track/?id=rounds/frere_jacques.mp3">Frère Jacques</a></li> -->
-<li><a href="/track/?id=Greensleeves.mp3">Greensleeves</a></li>
-<li><a href="/track/?id=farandole_bizet.mp3">Bizet – Farandole (from L’Arlésienne)</a></li>
-</ul>
+<body>
+  <h1>Hybrid Classical Library</h1>
+  <p class="meta">Tap a piece to open it in the app. Links are privacy-safe and bookmarkable.</p>
 
+  <h2>Rounds / Canons</h2>
+  <ul>
+    <li><a href="/track/?id=frere_jacques.mp3">Frère Jacques</a></li>
+    <li><a href="/track/?id=Greensleeves.mp3">Greensleeves</a></li>
+    <li><a href="/track/?id=farandole_bizet.mp3">Bizet Farandole (from L’Arlésienne)</a></li>
+  </ul>
 
+  <h2>Folk Tunes</h2>
+  <ul></ul>
 
-<h2>Folk Tunes</h2>
-<ul></ul>
+  <h2>Baroque</h2>
+  <ul></ul>
 
-<h2>Baroque</h2>
-<ul></ul>
+  <div class="footer">
+    <p class="meta">Last updated: 8 September 2025</p>
+    <p><a href="https://hybridclassical.ai">← Back to the App</a></p>
+  </div>
 
-<div class="footer">
-  <p class="meta">Last updated: 8 September 2025</p>
-  <p><a href="https://hybridclassical.ai/">← Back to the App</a></p>
-</div>
+  <!-- Picker script -->
+  <script>
+  (() => {
+    const params = new URLSearchParams(location.search);
+    const isPicker = params.get('mode') === 'picker';
+    if (!isPicker) return;
+
+    document.documentElement.classList.add('hc-picker');
+
+    document.addEventListener('click', (e) => {
+      const a = e.target.closest('a[href]');
+      if (!a) return;
+      const href = a.getAttribute('href') || '';
+      if (!/\.(mp3|mp4)(\?|#|$)/i.test(href)) return;
+      e.preventDefault();
+
+      const absolute = new URL(href, location.href).href;
+      window.opener?.postMessage({ type: 'HC_SELECT_URL', url: absolute }, '*');
+      try { window.close(); } catch(_) {}
+    });
+  })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
	•	Add ?mode=picker to /library to post selected MP3/MP4 back to opener and close.
	•	Parent opens library via window.open, listens for HC_SELECT_URL, then loads track.